### PR TITLE
Update test environment

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,8 +22,8 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-22.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-22.04,   r: 'release'}
+          - {os: ubuntu-24.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-24.04,   r: 'release'}
           - {os: ubuntu-22.04,   r: 'oldrel-1'}
 
     env:
@@ -32,7 +32,7 @@ jobs:
       R_BIOC_VERSION: 3.22
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
This PR updates the GitHub action to test against a current version of ubuntu (24.04, retaining 22.04 for testing against `oldrel`), and to use the latest `actions/checkout@v5` action.

(Not sure why commits from a previous PR are also listed here – I must have not synced my repo properly - a squash and merge should take care of these.)