### PR TITLE
Fix header for /collections POST

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -66,7 +66,7 @@ phy_POST <- function(path, body = list(), ...) {
   tryCatch({
     resp <- POST(url = pbase(), path = path, body = body,
                  add_headers(
-                   "Content-type" = "application/vnd.phylopic.v2+json"
+                   "Content-type" = "application/json"
                  ),
                  encode = "raw")
   }, error = function(e) {


### PR DESCRIPTION
`get_attribution(..., permalink = TRUE)` is currently broken due to the breaking API change reported in https://github.com/keesey/phylopic/issues/69. This fixes it. If we don't hear back from @keesey soon, we should merge this and push a quick patch version to CRAN. However, I'm hoping the change was unintentional and the API behavior will be restored, in which case we wouldn't want to merge this.